### PR TITLE
Add GeoIP database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ You can find statistics of all your Fall Guys sessions by opening File Explorer 
 
 In here you will find a file named `stats.csv` which you can open with Excel or import in to Google Sheets or many other tools / programming languages
 
+## Install the GeoIP Database
+
+There is now an option to use an IP database to lookup the server location dynamically. This database must be installed manually after registering for a free account.
+
+1. Go to https://dev.maxmind.com/geoip/geolite2-free-geolocation-data
+1. Click "Signup for GeoLite2" (It is a free account)
+2. Login to your account
+3. Click on "Download Databases" or "Download Files"
+4. In the "GeoLite2 City" section with format:
+GeoIP2 Binary (.mmdb), click "Download GZIP"
+5. Decompress the downloaded file. You might need a tool like [7-zip](https://www.7-zip.org/) to decompress it
+6. Decompress the .tar file
+7. You should have a folder with a `GeoLite2-City.mmdb` file in it. 
+8. Copy `GeoLite2-City.mmdb` into `%APPDATA%\fgpe\` which should be like `C:\Users\your_user_name\AppData\Roaming\fgpe`
+9. Restart Fall Guys Ping Estimate
+
 ## Report Unknown Region / Location
 
 Because the region and location is built manually there will likely be many ip addresses where the region and location are not known. When this happens you will see the IP address displayed instead of the region and locations.
@@ -69,7 +85,7 @@ python -m pip install pyinstaller
 Build the installer (will create an exe at dist\run_fgpe.exe):
 
 ```
-pyinstaller installer\run_fgpe.py --clean --add-data "fgpe/data/*;fgpe/data" --noconsole --onefile --icon installer\fall_guy.ico
+python -m PyInstaller installer\run_fgpe.py --clean --add-data "fgpe/data/*;fgpe/data" --noconsole --onefile --icon installer\fall_guy.ico
 ```
 
 

--- a/fgpe/locations.py
+++ b/fgpe/locations.py
@@ -31,20 +31,14 @@ class LocationLookup:
         self.download_csv_file_path = Path(expandvars(r'%APPDATA%\fgpe\Fall_Guys_IP_Networks.csv'))
         self._ip_network_lookup = None
 
-        geoip_path = Path(expandvars(r'%APPDATA%\fgpe\GeoLite2-City.mmdb'))
-        self._use_geoip = geoip_path.exists()
-        if self._use_geoip:
-            self._geoip_reader = geoip2.database.Reader(geoip_path)
+        self.geoip_path = Path(expandvars(r'%APPDATA%\fgpe\GeoLite2-City.mmdb'))
+        self._use_geoip = self.geoip_path.exists()
 
         # Check unknown IP address CSV exists
         self.unknown_ip_path = Path(expandvars(r'%APPDATA%\fgpe\unknown_ip_addresses.csv'))
         self.unknown_ip_path.parent.mkdir(parents=True, exist_ok=True)
         if not self.unknown_ip_path.exists():
             self.unknown_ip_path.write_text('Time,IP Address\n')
-    
-    def __del__(self):
-        if self._use_geoip:
-            self._geoip_reader.close()
 
     @property
     def csv_file_path(self) -> Path:
@@ -74,8 +68,12 @@ class LocationLookup:
     def lookup(self, ip_str: str, record_unknown: bool = True) -> FallGuysLocation:
         ip_addr = ip_address(ip_str)
         if self._use_geoip:
-            geoip_response = self._geoip_reader.city(ip_addr)
-            return FallGuysLocation(geoip_response.country.name, geoip_response.city.name, 'Unknown')
+            with geoip2.database.Reader(self.geoip_path) as reader:
+                try:
+                    geoip_response = reader.city(ip_addr)
+                    return FallGuysLocation(geoip_response.country.name, geoip_response.city.name, 'Unknown')
+                except geoip2.errors.AddressNotFoundError:
+                    return UNKNOWN_LOCATION
 
         for network, location in self.ip_network_lookup.items():
             if ip_addr in network:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 psutil
 requests
+geoip2

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'psutil',
-        'requests'
+        'requests',
+        'geoip2'
     ],
 )


### PR DESCRIPTION
Adds an option to use an IP database to lookup the server location dynamically. If the IP database file is not found FGPE will work as normal using the CSV IP list. I have not coded with python before so please correct any mistakes.